### PR TITLE
Fix for human readable output format

### DIFF
--- a/cmd/seekret/format.go
+++ b/cmd/seekret/format.go
@@ -32,7 +32,7 @@ func FormatOutput(secretList []models.Secret, format string) string {
 func formatOutputHuman(secretList []models.Secret) (string, error) {
 	var out string
 	for _, s := range secretList {
-		out = out + fmt.Sprintf("%s\n\t%d: [%s] %s %s\n", s.Object.Name, s.Nline, s.Rule.Name, s.Line, s.Exception)
+		out = out + fmt.Sprintf("%s\n\t%d: [%s] %s %t\n", s.Object.Name, s.Nline, s.Rule.Name, s.Line, s.Exception)
 	}
 	return out, nil
 }


### PR DESCRIPTION
The following fix changes the format output from 

```
$ seekret --rules /path/to/seekret-rules dir /path/to/secretsfile.txt               
/path/to/secretsfile.txt
	1: [a.secret_access_key] a_secret_access_key: 1234567890123456789012345678901234567890 %!s(bool=false)

```

to:

```
$ seekret --rules /path/to/seekret-rules dir /path/to/secretsfile.txt               
/path/to/secretsfile.txt
	1: [a.secret_access_key] a_secret_access_key: 1234567890123456789012345678901234567890 false

```
